### PR TITLE
Coveralls lisätty ja badge readme:hin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,6 @@ addons:
     packages:
       - libstdc++-4.9-dev
       - google-chrome-stable
+
+after_success:
+- ./gradlew jacocoTestReport coveralls

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/nullkaaryle/ohtu-miniprojekti-takarivi.svg?branch=master)](https://travis-ci.org/nullkaaryle/ohtu-miniprojekti-takarivi)
 
+[![Coverage Status](https://coveralls.io/repos/github/nullkaaryle/ohtu-miniprojekti-takarivi/badge.svg?branch=master)](https://coveralls.io/github/nullkaaryle/ohtu-miniprojekti-takarivi?branch=master)
+
 Käynnistysohje: kloonaa repo, ./gradlew bootRun ja localhost:8080 selaimeen
 
 Projektin backlog löytyy osoitteesta: https://docs.google.com/spreadsheets/d/1v_jMJRVM1mLPh5Sm7ex8Jp6xdQSvrPyKVsJDBoWsNjA/edit#gid=633844401 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'com.github.kt3k.coveralls' version '2.8.1'
+}
+
 buildscript {
 	ext {
 		springBootVersion = '1.5.2.RELEASE'
@@ -79,6 +83,13 @@ dependencies {
 
 test {
     testLogging.showStandardStreams = true
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
 }
 
 task(debug, dependsOn: 'classes', type: JavaExec)


### PR DESCRIPTION
Lisättty build-gradleen rivit:

plugins {
    id 'com.github.kt3k.coveralls' version '2.8.1'
}

jacocoTestReport {
    reports {
        xml.enabled = true // coveralls plugin depends on xml format report
        html.enabled = true
    }
}

ja travis.yml:ään rivit:

after_success:
- ./gradlew jacocoTestReport coveralls